### PR TITLE
Wallet id has wrong integer type

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -138,8 +138,7 @@
             "description": "id of the wallet",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],


### PR DESCRIPTION
Wallet id at the "/accounts/{walletid}" should be a string , because it cointains numbers and letters..